### PR TITLE
change the encoding to gbk while current platform is Windows

### DIFF
--- a/src/main/java/Crawler.java
+++ b/src/main/java/Crawler.java
@@ -54,7 +54,7 @@ public class Crawler {
 
         log.info("Version is " + version);
         log.info("PC platform : " +  System.getProperty("os.name"));
-
+        log.info("System File Encoding: " + System.getProperty("file.encoding"));
         CommandLineParser parser = new DefaultParser( );
         Options options = new Options( );
         options.addOption("h", "help", false, "Print this usage information");

--- a/src/main/java/util/ReportUtil.java
+++ b/src/main/java/util/ReportUtil.java
@@ -33,6 +33,9 @@ public class ReportUtil {
     public static void generateReport(File file){
         builder = new StringBuilder();
         String meta = "utf-8";
+        if(Util.isWin()){
+            meta = "gbk";
+        }
 
         builder.append("<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">\n" + "<html>\n" + "<head>\n" );
         builder.append("    <meta http-equiv=\"Content-Type\" content=\"text/html; charset="+ meta +"\" />\n");

--- a/src/main/java/util/Util.java
+++ b/src/main/java/util/Util.java
@@ -237,8 +237,7 @@ public final class Util {
         String charsetName = "UTF-8";
 
         if(Util.isWin()){
-            //charsetName = "GBK";
-            charsetName = "GB2312";
+            charsetName = "GBK";
         }
 
         log.info("charetName is set to : " + charsetName);


### PR DESCRIPTION
The encoding of windows is GBK by default, so change the report file's encoding to gbk while current platform is Windows. fix https://github.com/lgxqf/UICrawler/issues/3 